### PR TITLE
fix: correct RESEND_FROM_EMAIL env key to enable notification provider

### DIFF
--- a/backend/src/lib/constants.ts
+++ b/backend/src/lib/constants.ts
@@ -70,7 +70,7 @@ export const MINIO_BUCKET = process.env.MINIO_BUCKET; // Optional, if not set bu
  * (optional) Resend API Key and from Email - do not set if using SendGrid
  */
 export const RESEND_API_KEY = process.env.RESEND_API_KEY;
-export const RESEND_FROM_EMAIL = process.env.RESEND_FROM;
+export const RESEND_FROM_EMAIL = process.env.RESEND_FROM_EMAIL;
 
 /**
  * (optionl) SendGrid API Key and from Email - do not set if using Resend


### PR DESCRIPTION
This PR fixes a bug where the Resend notification provider was not being registered due to a mismatch in the environment variable key.

What was wrong:

In lib/constants.ts, RESEND_FROM_EMAIL was incorrectly set to process.env.RESEND_FROM instead of process.env.RESEND_FROM_EMAIL.

As a result, the resend provider block in medusa-config.ts was skipped, and notification templates relying on it failed to send.

Fix:

Updated the constant to use the correct environment variable key: process.env.RESEND_FROM_EMAIL.

✅ This fix ensures the Resend provider is properly registered and email notifications (like invite-user) can be sent successfully.

No breaking changes.